### PR TITLE
improve: correct calculation of file size when using stripHash function.

### DIFF
--- a/packages/size-plugin-core/util.js
+++ b/packages/size-plugin-core/util.js
@@ -23,3 +23,16 @@ function toFileMap(files) {
     }, {});
 }
 exports.toFileMap = toFileMap;
+
+function getStripHashedFileSize(originSizeMap) {
+  return Object.keys(originSizeMap).reduce((acc, currentValue, currentIndex, array) => {
+    const stripedName = this.options.stripHash(currentValue);
+    if(acc[stripedName]) {
+      acc[stripedName] = acc[stripedName] + originSizeMap[currentValue]
+    } else {
+      acc[stripedName] = originSizeMap[currentValue]
+    }
+    return acc
+  }, {})
+}
+exports.getStripHashedFileSize = getStripHashedFileSize;


### PR DESCRIPTION
when using stripHash functioin. the filename

file structor

```bash
├── assets
│   ├── Add-05e23941.js
│   ├── IconButton-d130f323.js
│   ├── KeyboardArrowRight-2ba4ba71.js
│   ├── Popper-c8879c88.js
│   ├── TablePagination-f3e5f6f4.js
│   ├── index-26d0922c.js
│   ├── index-2b6194b2.js
│   ├── index-3a757292.js
│   ├── index-5fa2d481.js
│   ├── index-6227e1d5.js
│   ├── index-959e0bf0.js
│   ├── index-96869e9a.js
│   ├── index-9b2e168d.js
│   ├── index-bc581656.js
│   └── index-efdcc4d5.js
├── index.html
└── vite.svg
```

```yml
name: Compressed Size

on: [pull_request]

jobs:
  build:
    runs-on: ubuntu-latest
    permissions:
      pull-requests: write
      contents: read
    steps:
      - uses: actions/checkout@v2
      - uses: ./.github/actions/size
        with:
          strip-hash: "\\-(\\w{8})\\.js$"
          compression: "none"
          build-script: "build:notsc"
```

before: If the fileName remains unchanged after the stripHash function(index-efdcc4d5.js  -> index-********.js, index-bc581656.js -> index-********.js and other index files), the file size will only be calculated once.

after: file size should be calculated together.